### PR TITLE
Remove use of Chainguard's Golang image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM cgr.dev/chainguard/go:1.20.1 as build
+FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/wolfi-base as build
+RUN apk update && apk add build-base git openssh go-1.20
 WORKDIR /srv/app
 
 COPY go.mod go.sum ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/wolfi-base as build
-RUN apk update && apk add build-base git openssh go-1.20
+RUN apk update && apk add build-base git openssh go=1.20.6
 WORKDIR /srv/app
 
 COPY go.mod go.sum ./


### PR DESCRIPTION
Following tailscale/golink's lead.

Fixes #4. 