### PR TITLE
ci: also build the docker image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,3 +9,4 @@ jobs:
         go-version: 1.19
     - uses: actions/checkout@v3
     - run: go test ./...
+    - run: docker build -t untrack-that-url .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,4 +9,19 @@ jobs:
         go-version: 1.19
     - uses: actions/checkout@v3
     - run: go test ./...
-    - run: docker build --build-arg BUILDPLATFORM=linux/amd64 -t untrack-that-url .
+  dockerImageBuild:
+    name: "docker build"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Build and push
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        platforms: linux/amd64
+        push: false
+        tags: untrack-that-url:latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,4 +9,4 @@ jobs:
         go-version: 1.19
     - uses: actions/checkout@v3
     - run: go test ./...
-    - run: docker build --platform linux/amd64 -t untrack-that-url .
+    - run: docker build --build-arg BUILDPLATFORM=linux/amd64 -t untrack-that-url .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,4 +9,4 @@ jobs:
         go-version: 1.19
     - uses: actions/checkout@v3
     - run: go test ./...
-    - run: docker build -t untrack-that-url .
+    - run: docker build --platform linux/amd64 -t untrack-that-url .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/wolfi-base as build
-RUN apk update && apk search -x go && apk add build-base git openssh go-1.20-1.20.6-r0
+RUN apk update && apk search -x go && apk add build-base git openssh go-1.20=1.20.6-r0
 
 WORKDIR /srv/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/wolfi-base as build
-RUN apk update && apk add build-base git openssh go=1.20.6
+RUN apk update && apk search -x go && apk add build-base git openssh go=1.20.6
 WORKDIR /srv/app
 
 COPY go.mod go.sum ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/wolfi-base as build
-RUN apk update && apk search -x go && apk add build-base git openssh go=1.20.6
+RUN apk update && apk search -x go && apk add build-base git openssh go-1.20-1.20.6-r0
+
 WORKDIR /srv/app
 
 COPY go.mod go.sum ./


### PR DESCRIPTION
Broken by #5, but caused by the lack of CI for Docker image specifically.